### PR TITLE
Fix losing in certain states

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -2,7 +2,6 @@ name: CI Workflow
 
 on:
   push:
-    branches: [ "main" ]
 
 permissions:
   contents: write
@@ -24,6 +23,7 @@ jobs:
         run: rm www/pkg/.gitignore
 
       - name: Deploy to GH pages
+        if: success() && github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: www

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasm_board_games"
 description = "TicTacTo and Four-in-a-row in Rust WASM with web-worker"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Simon B. Gasse"]
 edition = "2021"
 repository = "https://github.com/sgasse/wasm_board_games"

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ python3 -m http.server --bind 127.0.0.1
 Both games share the same backend _engine_: We build a tree of possible moves
 down to a certain depth. Now the player can either do a move, which will be
 tracked in the evaluator or we can request the next best move from the
-evaluator. The best move is calculated in a traditional manner by summing over
-the average position value of each move.
+evaluator. The best move is calculated in a traditional manner using the
+[minimax algorithm][minimax].
 
 ## Key Features
 
@@ -141,20 +141,21 @@ documentation everywhere but only where I need it myself.
 
 ~ Simon B. Gasse
 
-[install_rust]: https://www.rust-lang.org/tools/install
-[html_canvas]: https://www.w3schools.com/html/html5_canvas.asp
-[wasm-pack]: https://github.com/rustwasm/wasm-pack
-[wasm-bindgen]: https://github.com/rustwasm/wasm-bindgen
-[web-sys]: https://rustwasm.github.io/wasm-bindgen/web-sys/index.html
-[wasm-worker]: https://github.com/sgasse/wasm_worker_interaction
-[rust_book]: https://doc.rust-lang.org/book/
-[int_mut]: https://doc.rust-lang.org/book/ch15-05-interior-mutability.html
-[match]: https://doc.rust-lang.org/book/ch06-02-match.html
-[if_let]: https://doc.rust-lang.org/book/ch06-03-if-let.html
-[result]: https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html
-[enum_variants]: https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html
-[iter]: https://doc.rust-lang.org/book/ch13-02-iterators.html
-[wasm_book_render]: https://rustwasm.github.io/docs/book/game-of-life/implementing.html#rendering-to-canvas-directly-from-memory
 [decl_macros]: https://doc.rust-lang.org/book/ch19-06-macros.html#declarative-macros-with-macro_rules-for-general-metaprogramming
+[enum_variants]: https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html
 [generics]: https://doc.rust-lang.org/rust-by-example/generics.html
+[html_canvas]: https://www.w3schools.com/html/html5_canvas.asp
+[if_let]: https://doc.rust-lang.org/book/ch06-03-if-let.html
+[install_rust]: https://www.rust-lang.org/tools/install
+[int_mut]: https://doc.rust-lang.org/book/ch15-05-interior-mutability.html
+[iter]: https://doc.rust-lang.org/book/ch13-02-iterators.html
+[match]: https://doc.rust-lang.org/book/ch06-02-match.html
+[minimax]: https://en.wikipedia.org/wiki/Minimax
+[result]: https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html
+[rust_book]: https://doc.rust-lang.org/book/
 [traits]: https://doc.rust-lang.org/book/ch10-02-traits.html
+[wasm_book_render]: https://rustwasm.github.io/docs/book/game-of-life/implementing.html#rendering-to-canvas-directly-from-memory
+[wasm-bindgen]: https://github.com/rustwasm/wasm-bindgen
+[wasm-pack]: https://github.com/rustwasm/wasm-pack
+[wasm-worker]: https://github.com/sgasse/wasm_worker_interaction
+[web-sys]: https://rustwasm.github.io/wasm-bindgen/web-sys/index.html

--- a/src/fiar_game.rs
+++ b/src/fiar_game.rs
@@ -80,6 +80,10 @@ impl GameState for FiarGameState {
             Cell::Empty => return 0,
         }
     }
+
+    fn side(&self) -> Cell {
+        self.last_move.side
+    }
 }
 
 #[cfg(test)]

--- a/src/fiar_game.rs
+++ b/src/fiar_game.rs
@@ -88,8 +88,7 @@ impl GameState for FiarGameState {
 
 #[cfg(test)]
 mod test {
-
-    use crate::{Board, BoardMove, Cell, Coords, FiarGameState, GameState};
+    use crate::*;
 
     #[test]
     fn test_fiargamestate_expand() -> Result<(), ()> {

--- a/src/game_interface.rs
+++ b/src/game_interface.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::prelude::*;
 use web_sys::console;
 
 #[wasm_bindgen]
+#[derive(PartialEq)]
 pub enum ExpandResult {
     Done,
     NotDone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,4 +23,5 @@ pub trait GameState {
     where
         Self: Sized;
     fn position_value(&self) -> i32;
+    fn side(&self) -> Cell;
 }

--- a/src/t3_game.rs
+++ b/src/t3_game.rs
@@ -77,6 +77,10 @@ impl GameState for T3GameState {
             Cell::Empty => return 0,
         }
     }
+
+    fn side(&self) -> Cell {
+        self.last_move.side
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Instead of using the worst-case value of all children of a move as should be the case in a [minimax algorithm](https://en.wikipedia.org/wiki/Minimax), we were using the average, which led the AI to lose in a few states. This fix changes the logic to use the worst-case value from the children and renames the fields accordingly.